### PR TITLE
Added rate limiting following NGINX rate limiting instructions.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,8 @@ http {
                            '"$http_referer" "$http_user_agent" "$gzip_ratio"';
     sendfile on;
 
+    limit_req_zone $binary_remote_addr zone=limitbyaddr:10m rate=30r/s;
+    limit_req_status 429;
 
     server {
         listen 80 default_server;
@@ -22,6 +24,7 @@ http {
 
         location / {
             # rewrite /ui/(.*) /$1 break;
+            limit_req zone=limitbyaddr burst=10 nodelay;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Tested worked when port forwarding on VSCode, didn't work using script against localhost. But from the PF it would throw error code 429: Too many request when either too many request in a short period or over the limit.